### PR TITLE
Nahrazen externí dig vestavěnou php funkcí

### DIFF
--- a/app/Check/Consumers/DnsCheck.php
+++ b/app/Check/Consumers/DnsCheck.php
@@ -12,14 +12,14 @@ class DnsCheck extends Check
 	protected function doHardJob(\Pd\Monitoring\Check\Check $check): bool
 	{
 		$check->lastIp = NULL;
-		$process = new \Symfony\Component\Process\Process(sprintf('/usr/bin/dig %s A +short', $check->url));
-		try {
-			$process->mustRun();
-			$check->lastIp = trim($process->getOutput());
-		} catch (\Symfony\Component\Process\Exception\ProcessFailedException $e) {
+
+		$entries = dns_get_record($check->url, DNS_A);
+		if (!$entries) {
 			return FALSE;
 		}
 
+		$entry = array_shift($entries);
+		$check->lastIp = $entry['ip'];
 		return TRUE;
 	}
 


### PR DESCRIPTION
Systémová závislost je těžko portovatelná a typicky
v systému nebude. Tato funkce je v php dostupná vždy.