### PR TITLE
Přidána kontrola DNS CNAME záznamů

### DIFF
--- a/app/Check/ChecksRepository.php
+++ b/app/Check/ChecksRepository.php
@@ -21,6 +21,7 @@ class ChecksRepository extends Nextras\Orm\Repository\Repository
 			AliveCheck::class,
 			TermCheck::class,
 			DnsCheck::class,
+			DnsCnameCheck::class,
 			CertificateCheck::class,
 			FeedCheck::class,
 			RabbitConsumerCheck::class,
@@ -39,6 +40,8 @@ class ChecksRepository extends Nextras\Orm\Repository\Repository
 					return TermCheck::class;
 				case ICheck::TYPE_DNS:
 					return DnsCheck::class;
+				case ICheck::TYPE_DNS_CNAME:
+					return DnsCnameCheck::class;
 				case ICheck::TYPE_CERTIFICATE:
 					return CertificateCheck::class;
 				case ICheck::TYPE_FEED:

--- a/app/Check/Commands/Publish/DnsCnameChecksCommand.php
+++ b/app/Check/Commands/Publish/DnsCnameChecksCommand.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace Pd\Monitoring\Check\Commands\Publish;
+
+use Pd\Monitoring\Commands\TNamedCommand;
+
+class DnsCnameChecksCommand extends PublishChecksCommand
+{
+	use TNamedCommand;
+
+	protected function getConditions(): array
+	{
+		return [
+			'type' => \Pd\Monitoring\Check\ICheck::TYPE_DNS_CNAME,
+		];
+	}
+
+}

--- a/app/Check/Consumers/DnsCnameCheck.php
+++ b/app/Check/Consumers/DnsCnameCheck.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Pd\Monitoring\Check\Consumers;
+
+class DnsCnameCheck extends Check
+{
+
+	/**
+	 * @param \Pd\Monitoring\Check\Check|\Pd\Monitoring\Check\DnsCnameCheck $check
+	 * @return bool
+	 */
+	protected function doHardJob(\Pd\Monitoring\Check\Check $check): bool
+	{
+		$check->lastTarget = NULL;
+
+		$entries = dns_get_record($check->url, DNS_CNAME);
+		if (!$entries) {
+			return FALSE;
+		}
+
+		$entry = array_shift($entries);
+		$check->lastTarget = $entry['target'];
+		return TRUE;
+	}
+
+
+	protected function getCheckType(): int
+	{
+		return \Pd\Monitoring\Check\ICheck::TYPE_DNS_CNAME;
+	}
+}

--- a/app/Check/DnsCnameCheck.php
+++ b/app/Check/DnsCnameCheck.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace Pd\Monitoring\Check;
+
+/**
+ * @property string $url
+ * @property string $target
+ * @property string|NULL $lastTarget
+ */
+class DnsCnameCheck extends Check
+{
+
+	public function __construct()
+	{
+		parent::__construct();
+		$this->type = ICheck::TYPE_DNS_CNAME;
+	}
+
+
+	protected function getStatus(): int
+	{
+		if ($this->lastTarget === $this->target) {
+			return ICheck::STATUS_OK;
+		} else {
+			return ICheck::STATUS_ERROR;
+		}
+	}
+
+
+	public function getTitle(): string
+	{
+		return 'Nastavení DNS CNAME';
+	}
+
+
+	public function getterStatusMessage(): string
+	{
+		return $this->lastTarget !== $this->target ? sprintf('Očekávaná CNAME adresa "%s" neodpovídá zjištěné "%s"', $this->target, $this->lastTarget) : '';
+	}
+}

--- a/app/DashBoard/Controls/AddEditCheck/DnsCnameCheckProcessor.php
+++ b/app/DashBoard/Controls/AddEditCheck/DnsCnameCheckProcessor.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+namespace Pd\Monitoring\DashBoard\Controls\AddEditCheck;
+
+class DnsCnameCheckProcessor implements ICheckControlProcessor
+{
+
+	public function processEntity(\Pd\Monitoring\Check\Check $check, array $data)
+	{
+		$check->url = $data['url'];
+		$check->target = $data['target'];
+	}
+
+
+	public function getCheck(): \Pd\Monitoring\Check\Check
+	{
+		return new \Pd\Monitoring\Check\DnsCnameCheck();
+	}
+
+
+	public function createForm(\Pd\Monitoring\Check\Check $check, \Nette\Application\UI\Form $form)
+	{
+		$form->addGroup($check->getTitle());
+		$form
+			->addText('url', 'Adresa')
+			->setRequired(TRUE)
+		;
+		$form
+			->addText('target', 'Cíl')
+			->setRequired(TRUE)
+			->addFilter(function($value) {
+				return rtrim($value, '.');
+			});
+		;
+	}
+
+}

--- a/app/DashBoard/Controls/AddEditCheck/Factory.php
+++ b/app/DashBoard/Controls/AddEditCheck/Factory.php
@@ -40,6 +40,10 @@ class Factory
 				$control = new Control($project, $check, new DnsCheckProcessor(), $this->formFactory, $this->checksRepository);
 				break;
 
+			case \Pd\Monitoring\Check\ICheck::TYPE_DNS_CNAME:
+				$control = new Control($project, $check, new DnsCnameCheckProcessor(), $this->formFactory, $this->checksRepository);
+				break;
+
 			case \Pd\Monitoring\Check\ICheck::TYPE_CERTIFICATE:
 				$control = new Control($project, $check, new CertificateCheckProcessor(), $this->formFactory, $this->checksRepository);
 				break;

--- a/app/DashBoard/Controls/Check/Control.latte
+++ b/app/DashBoard/Controls/Check/Control.latte
@@ -17,6 +17,11 @@
 			<p>Očekávaná IP: {$check->ip}</p>
 			<p>Zjištěná IP: {if $check->lastIp}{$check->lastIp}{else}<span class="text-muted">není</span>{/if}</p>
 			<p>Poslední kontrola: {if $check->lastCheck}{$check->lastCheck|dateTime}{else}<span class="text-muted">neproběhla</span>{/if}</p>
+		{elseif $check instanceof Pd\Monitoring\Check\DnsCnameCheck}
+			<p>Testovaná adresa: <a href="{$check->url}">{$check->url}</a></p>
+			<p>Očekávaný cíl: {$check->target}</p>
+			<p>Zjištěný cíl: {if $check->lastTarget}{$check->lastTarget}{else}<span class="text-muted">není</span>{/if}</p>
+			<p>Poslední kontrola: {if $check->lastCheck}{$check->lastCheck|dateTime}{else}<span class="text-muted">neproběhla</span>{/if}</p>
 		{elseif $check instanceof Pd\Monitoring\Check\CertificateCheck}
 			<p>Testovaná adresa: <a href="{$check->url}">{$check->url}</a></p>
 			<p>Varování předem: {$check->daysBeforeWarning} dní</p>

--- a/app/DashBoard/Presenters/ProjectPresenter.php
+++ b/app/DashBoard/Presenters/ProjectPresenter.php
@@ -141,6 +141,7 @@ class ProjectPresenter extends BasePresenter
 			new \Pd\Monitoring\Check\AliveCheck(),
 			new \Pd\Monitoring\Check\TermCheck(),
 			new \Pd\Monitoring\Check\DnsCheck(),
+			new \Pd\Monitoring\Check\DnsCnameCheck(),
 			new \Pd\Monitoring\Check\CertificateCheck(),
 			new \Pd\Monitoring\Check\FeedCheck(),
 			new \Pd\Monitoring\Check\RabbitConsumerCheck(),

--- a/app/config/config.neon
+++ b/app/config/config.neon
@@ -72,6 +72,9 @@ rabbitmq:
 		dnsCheck:
 			exchange: {name: 'dnsCheck', type: direct}
 			contentType: text/plain
+		dnsCnameCheck:
+			exchange: {name: 'dnsCnameCheck', type: direct}
+			contentType: text/plain
 		certificateCheck:
 			exchange: {name: 'certificateCheck', type: direct}
 			contentType: text/plain
@@ -91,6 +94,10 @@ rabbitmq:
 			exchange: {name: 'dnsCheck', type: direct}
 			queue: {name: 'dnsCheck'}
 			callback: [@Pd\Monitoring\Check\Consumers\DnsCheck, process]
+		dnsCnameCheck:
+			exchange: {name: 'dnsCnameCheck', type: direct}
+			queue: {name: 'dnsCnameCheck'}
+			callback: [@Pd\Monitoring\Check\Consumers\DnsCnameCheck, process]
 		certificateCheck:
 			exchange: {name: 'certificateCheck', type: direct}
 			queue: {name: 'certificateCheck'}
@@ -135,6 +142,9 @@ services:
 		class: Pd\Monitoring\Check\Consumers\DnsCheck
 
 	-
+		class: Pd\Monitoring\Check\Consumers\DnsCnameCheck
+
+	-
 		class: Pd\Monitoring\Check\Consumers\CertificateCheck
 
 	-
@@ -167,6 +177,13 @@ services:
 			- kdyby.console.command
 		arguments:
 			- @Kdyby\RabbitMq\Connection::getProducer('dnsCheck')
+
+	-
+		class: Pd\Monitoring\Check\Commands\Publish\DnsCnameChecksCommand
+		tags:
+			- kdyby.console.command
+		arguments:
+			- @Kdyby\RabbitMq\Connection::getProducer('dnsCnameCheck')
 
 	-
 		class: Pd\Monitoring\Check\Commands\Publish\CertificateChecksCommand

--- a/migrations/structures/2017-04-13-174952-dns-cname-check.sql
+++ b/migrations/structures/2017-04-13-174952-dns-cname-check.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `checks` ADD `target` VARCHAR(250)  NULL  DEFAULT NULL;
+ALTER TABLE `checks` ADD `last_target` VARCHAR(250)  NULL  DEFAULT NULL  AFTER `target`;


### PR DESCRIPTION
Php (a možná DNS) vrací hodnotu CNAME bez koncové tečky.
Pokud ji uživatel uvede, automaticky se smaže.

Částečně závisí na https://github.com/peckadesign/Monitoring/pull/50