### PR TITLE
Přidána podpora pro více než jeden A záznam

### DIFF
--- a/app/Check/Consumers/DnsCheck.php
+++ b/app/Check/Consumers/DnsCheck.php
@@ -18,8 +18,11 @@ class DnsCheck extends Check
 			return FALSE;
 		}
 
-		$entry = array_shift($entries);
-		$check->lastIp = $entry['ip'];
+		$ips = [];
+		foreach ($entries as $entry) {
+			$ips[] = $entry['ip'];
+		}
+		$check->lastIp = \Pd\Monitoring\Check\DnsCheck::normalizeIpList(implode(',', $ips));
 		return TRUE;
 	}
 

--- a/app/Check/DnsCheck.php
+++ b/app/Check/DnsCheck.php
@@ -27,6 +27,14 @@ class DnsCheck extends Check
 	}
 
 
+	public static function normalizeIpList(string $list): string
+	{
+		$ips = preg_split('~\s*[|;,]\s*~', $list, -1, PREG_SPLIT_NO_EMPTY);
+		sort($ips, SORT_NATURAL);
+		return implode(', ', $ips);
+	}
+
+
 	public function getTitle(): string
 	{
 		return 'Nastavení DNS';

--- a/app/DashBoard/Controls/AddEditCheck/DnsCheckProcessor.php
+++ b/app/DashBoard/Controls/AddEditCheck/DnsCheckProcessor.php
@@ -2,6 +2,8 @@
 
 namespace Pd\Monitoring\DashBoard\Controls\AddEditCheck;
 
+use Pd\Monitoring\Check\DnsCheck;
+
 class DnsCheckProcessor implements ICheckControlProcessor
 {
 
@@ -28,6 +30,9 @@ class DnsCheckProcessor implements ICheckControlProcessor
 		$form
 			->addText('ip', 'IP adresa')
 			->setRequired(TRUE)
+			->addFilter(function($value) {
+				return DnsCheck::normalizeIpList($value);
+			})
 		;
 	}
 


### PR DESCRIPTION
Toto je nezbytné například pro AWS Route53 alias, který se typicky
používá pro Load Balancer.

Závislé na #50