### PR TITLE
Upozornění na návrat k očekávané hodnotě

### DIFF
--- a/app/Check/Check.php
+++ b/app/Check/Check.php
@@ -8,6 +8,7 @@ namespace Pd\Monitoring\Check;
  * @property SlackNotifyLock $locks {1:m SlackNotifyLock::$check, cascade=[persist, remove]}
  * @property int $type {enum ICheck::TYPE_*}
  * @property int $status {virtual}
+ * @property bool $awaitingRecovery
  * @property \DateTime|NULL $lastCheck
  * @property bool $paused {default TRUE}
  * @property string|NULL $name
@@ -35,6 +36,7 @@ abstract class Check extends \Nextras\Orm\Entity\Entity implements
 		parent::__construct();
 
 		$this->status = ICheck::STATUS_ERROR;
+		$this->awaitingRecovery = FALSE;
 	}
 
 

--- a/app/Check/Commands/SlackCheckStatusesCommand.php
+++ b/app/Check/Commands/SlackCheckStatusesCommand.php
@@ -2,6 +2,8 @@
 
 namespace Pd\Monitoring\Check\Commands;
 
+use Pd\Monitoring\Check\ICheck;
+
 class SlackCheckStatusesCommand extends \Symfony\Component\Console\Command\Command
 {
 
@@ -90,6 +92,24 @@ class SlackCheckStatusesCommand extends \Symfony\Component\Console\Command\Comma
 				}
 			}
 
+			$url = $this->linkGenerator->link('DashBoard:Project:', [$check->project->id]);
+			$checkStatusMessage = $check->statusMessage;
+
+			if ($check->awaitingRecovery && $check->status === ICheck::STATUS_OK) {
+				$message = sprintf(
+					'Pro <%s|projekt %s> se kontrola vrátila do normálu: %s%s',
+					$url,
+					$check->project->name,
+					$check->fullName,
+					$checkStatusMessage ? ': ' . $checkStatusMessage : ''
+				);
+
+				$this->slackNotifier->notify($message, 'good');
+				$check->awaitingRecovery = FALSE;
+				$this->checksRepository->persistAndFlush($check);
+				continue;
+			}
+
 			$conditions = [
 				'check' => $check,
 			];
@@ -100,8 +120,6 @@ class SlackCheckStatusesCommand extends \Symfony\Component\Console\Command\Comma
 			if ($lastLock && $lastLock->status === $check->status && $lastLock->locked >= $this->dateTimeProvider->getDateTime()->sub(new \DateInterval('PT60M'))) {
 				continue;
 			}
-
-			$url = $this->linkGenerator->link('DashBoard:Project:', [$check->project->id]);
 
 			switch ($check->status) {
 				case \Pd\Monitoring\Check\ICheck::STATUS_ALERT:
@@ -118,9 +136,10 @@ class SlackCheckStatusesCommand extends \Symfony\Component\Console\Command\Comma
 			$lock->locked = $this->dateTimeProvider->getDateTime();
 			$lock->status = $check->status;
 			$lock->check = $check;
-			$this->slackNotifyLocksRepository->persistAndFlush($lock);
+			$this->slackNotifyLocksRepository->persist($lock);
 
-			$checkStatusMessage = $check->statusMessage;
+			$check->awaitingRecovery = TRUE;
+			$this->checksRepository->persistAndFlush($check);
 
 			$message = sprintf(
 				'Pro <%s|projekt %s> je zaznamenán problém v kontrole %s%s',

--- a/migrations/structures/2017-04-13-184410-notify-on-recovery.sql
+++ b/migrations/structures/2017-04-13-184410-notify-on-recovery.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `checks`
+ADD `awaiting_recovery` tinyint NOT NULL DEFAULT 0;


### PR DESCRIPTION
Záměrně prolamuje lock timeout, aby upozornění
na recovery přišlo co nejdříve.