### PR TITLE
Nastavenie “” pre User->slackId pri vytvarani usera.

### DIFF
--- a/app/User/User.php
+++ b/app/User/User.php
@@ -12,7 +12,7 @@ use Nextras;
  * @property string $gitHubName
  * @property string $gitHubToken
  * @property bool $administrator
- * @property string $slackId
+ * @property string $slackId {default ""}
  * @property \Nextras\Orm\Relationships\OneHasMany|\Pd\Monitoring\UsersFavoriteProject\UsersFavoriteProject[] $favoriteProjects {1:m \Pd\Monitoring\UsersFavoriteProject\UsersFavoriteProject::$user}
  * @property \Nextras\Orm\Relationships\OneHasMany|\Pd\Monitoring\UserSlackNotifications\UserSlackNotifications[] $userSlackNotifications {1:m \Pd\Monitoring\UserSlackNotifications\UserSlackNotifications::$user}
  */


### PR DESCRIPTION
Riesim s @landsman beh v Docker kontaineroch a chybajuci slackId property pri "registracii" usera via GHub.