### PR TITLE
Prázdná hodnota SlackId u uživatele je NULL

### DIFF
--- a/app/DashBoard/Forms/UserEditFormFactory.php
+++ b/app/DashBoard/Forms/UserEditFormFactory.php
@@ -34,7 +34,10 @@ class UserEditFormFactory
 		$form = $this->factory->create();
 
 		$form->addText(self::FIELD_GIT_HUB_NAME, 'Jméno');
-		$form->addText(self::FIELD_SLACK_ID, 'Slack ID');
+		$form
+			->addText(self::FIELD_SLACK_ID, 'Slack ID')
+			->setNullable(TRUE)
+		;
 
 		if ($this->user->isAllowed('user', 'edit')) {
 			$form->addCheckbox(self::FIELD_ADMINISTRATOR, 'Administrátor');

--- a/app/User/User.php
+++ b/app/User/User.php
@@ -12,7 +12,7 @@ use Nextras;
  * @property string $gitHubName
  * @property string $gitHubToken
  * @property bool $administrator
- * @property string $slackId
+ * @property string|null $slackId
  * @property \Nextras\Orm\Relationships\OneHasMany|\Pd\Monitoring\UsersFavoriteProject\UsersFavoriteProject[] $favoriteProjects {1:m \Pd\Monitoring\UsersFavoriteProject\UsersFavoriteProject::$user}
  * @property \Nextras\Orm\Relationships\OneHasMany|\Pd\Monitoring\UserSlackNotifications\UserSlackNotifications[] $userSlackNotifications {1:m \Pd\Monitoring\UserSlackNotifications\UserSlackNotifications::$user}
  */

--- a/migrations/structures/2017-11-05-130500-slackid-null.sql
+++ b/migrations/structures/2017-11-05-130500-slackid-null.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `users`
+CHANGE `slack_id` `slack_id` varchar(255) COLLATE 'utf8_general_ci' NULL;
+
+UPDATE `users` SET
+`slack_id` = NULL
+WHERE `slack_id` = '';


### PR DESCRIPTION
Omylem jsme zanesli jako výchozí hodnotu string a nutnost mít vyplněnou hodnotu u uživatele v databázi. Při zakládání uživatele přes GitHub tak aplikace spadne. Nahlášeno v PR #79.